### PR TITLE
Prepare v0.6.0

### DIFF
--- a/Keychaining.podspec
+++ b/Keychaining.podspec
@@ -28,7 +28,11 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/woin2ee/Keychaining.git', :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
-  s.ios.deployment_target = '11.0'
+  # `any` keyword is available since Swift 5.6
+  # Required to use Swift 5.6 is macOS Monterey 12
+  # macOS Monterey 12 supports iOS 12.4 and later.
+  s.ios.deployment_target = '12.4'
+  
   s.swift_versions = '5.7'
 
   s.source_files = 'Sources/*.swift'

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		DA90691C29C5F32500535A3D /* KeychainQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA90691B29C5F32500535A3D /* KeychainQuery.swift */; };
 		DA90691E29C5F3BD00535A3D /* KeychainItemKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA90691D29C5F3BD00535A3D /* KeychainItemKey.swift */; };
 		DA90692029C5F3D000535A3D /* KeychainItemValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA90691F29C5F3D000535A3D /* KeychainItemValue.swift */; };
-		DA90692829C6042E00535A3D /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA90692729C6042E00535A3D /* KeychainError.swift */; };
+		DA90692829C6042E00535A3D /* KeychainStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA90692729C6042E00535A3D /* KeychainStatus.swift */; };
 		DA9069D329CC818D00535A3D /* Dictionary+asCFDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9069D229CC818D00535A3D /* Dictionary+asCFDictionary.swift */; };
 		DA906A4329CF692300535A3D /* OSStatus+toReadableString.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA906A4229CF692200535A3D /* OSStatus+toReadableString.swift */; };
 		EA767D1266A1B893A60FDBFF423BFD50 /* Pods-Keychaining_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DBB8962F036E32304F43320F9BBBADB6 /* Pods-Keychaining_Tests-dummy.m */; };
@@ -56,7 +56,7 @@
 		DA90691B29C5F32500535A3D /* KeychainQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainQuery.swift; sourceTree = "<group>"; };
 		DA90691D29C5F3BD00535A3D /* KeychainItemKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainItemKey.swift; sourceTree = "<group>"; };
 		DA90691F29C5F3D000535A3D /* KeychainItemValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainItemValue.swift; sourceTree = "<group>"; };
-		DA90692729C6042E00535A3D /* KeychainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainError.swift; sourceTree = "<group>"; };
+		DA90692729C6042E00535A3D /* KeychainStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStatus.swift; sourceTree = "<group>"; };
 		DA9069D229CC818D00535A3D /* Dictionary+asCFDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+asCFDictionary.swift"; sourceTree = "<group>"; };
 		DA906A4229CF692200535A3D /* OSStatus+toReadableString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OSStatus+toReadableString.swift"; sourceTree = "<group>"; };
 		DBB8962F036E32304F43320F9BBBADB6 /* Pods-Keychaining_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Keychaining_Tests-dummy.m"; sourceTree = "<group>"; };
@@ -104,7 +104,7 @@
 				DA90691B29C5F32500535A3D /* KeychainQuery.swift */,
 				DA90691D29C5F3BD00535A3D /* KeychainItemKey.swift */,
 				DA90691F29C5F3D000535A3D /* KeychainItemValue.swift */,
-				DA90692729C6042E00535A3D /* KeychainError.swift */,
+				DA90692729C6042E00535A3D /* KeychainStatus.swift */,
 			);
 			name = Sources;
 			path = ../Sources;
@@ -329,7 +329,7 @@
 				DA5499C629D00DBD0008A4C0 /* Error+asKeychainError.swift in Sources */,
 				231704CBD15AF5E250E6C6F4AC5EBA4C /* Keychaining-dummy.m in Sources */,
 				DA906A4329CF692300535A3D /* OSStatus+toReadableString.swift in Sources */,
-				DA90692829C6042E00535A3D /* KeychainError.swift in Sources */,
+				DA90692829C6042E00535A3D /* KeychainStatus.swift in Sources */,
 				DA90691629C5EFBC00535A3D /* Keychain.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -501,7 +501,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/Keychaining/Keychaining-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/Keychaining/Keychaining-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -538,7 +538,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Target Support Files/Pods-Keychaining_Tests/Pods-Keychaining_Tests-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -578,7 +578,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/Keychaining/Keychaining-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/Keychaining/Keychaining-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -615,7 +615,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Target Support Files/Pods-Keychaining_Tests/Pods-Keychaining_Tests-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Sources/Error+asKeychainError.swift
+++ b/Sources/Error+asKeychainError.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension Error {
     
-    public var asKeychainError: KeychainError? {
-        self as? KeychainError
+    public var asKeychainError: KeychainStatus? {
+        self as? KeychainStatus
     }
 }

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -49,39 +49,91 @@ public struct Keychain {
      See the [`kSecClassIdentity`](https://developer.apple.com/documentation/security/ksecclassidentity) for the attributes that apply.
      */
     public static let identity: Keychain = .init(class: .identity)
+}
+
+// MARK: - Make query with initalized class type
+
+public extension Keychain {
     
     /**
      
      */
-    public func makeQuery() -> KeychainQuery {
+    func makeBasicQuery() -> KeychainBasicQuery {
         return .init(classValue: self.class)
     }
     
     /**
      
      */
-    public func makeSaveQuery() -> KeychainSaveQuery {
+    func makeSaveQuery() -> KeychainSaveQuery {
         return .init(classValue: self.class)
     }
     
     /**
      
      */
-    public func makeSearchQuery() -> KeychainSearchQuery {
+    func makeSearchQuery() -> KeychainSearchQuery {
         return .init(classValue: self.class)
     }
     
     /**
      
      */
-    public func makeUpdateQuery() -> KeychainUpdateQuery {
+    func makeUpdateQuery() -> KeychainUpdateQuery {
         return .init(classValue: self.class)
     }
     
     /**
      
      */
-    public func makeDeleteQuery() -> KeychainDeleteQuery {
+    func makeDeleteQuery() -> KeychainDeleteQuery {
         return .init(classValue: self.class)
+    }
+}
+
+// MARK: - Make query without initialized class type
+
+public extension Keychain {
+    
+    /**
+     
+     */
+    static func makeBasicQuery() -> KeychainBasicQuery {
+        return .init([:])
+    }
+    
+    /**
+     
+     */
+    static func makeSaveQuery() -> KeychainSaveQuery {
+        return .init([:])
+    }
+    
+    /**
+     
+     */
+    static func makeSearchQuery() -> KeychainSearchQuery {
+        return .init([:])
+    }
+    
+    /**
+     
+     */
+    static func makeUpdateQuery() -> KeychainUpdateQuery {
+        return .init([:])
+    }
+    
+    /**
+     
+     */
+    static func makeDeleteQuery() -> KeychainDeleteQuery {
+        return .init([:])
+    }
+    
+    /**
+     
+     */
+    static func makeDictionary() -> KeychainDictionary {
+        return .init()
     }
 }

--- a/Sources/KeychainItemValue.swift
+++ b/Sources/KeychainItemValue.swift
@@ -9,44 +9,48 @@ import Foundation
 
 protocol KeychainItemValue: RawRepresentable {}
 
-struct KeychainItemClassValue: KeychainItemValue {
+public struct KeychainItemClassValue: KeychainItemValue {
     
-    let rawValue: CFString
+    public let rawValue: CFString
+    
+    public init(rawValue: CFString) {
+        self.rawValue = rawValue
+    }
     
     /**
      The value that indicates a generic password item.
      
      A value wrapping the [`kSecClassGenericPassword`](https://developer.apple.com/documentation/security/ksecclassgenericpassword) value.
      */
-    static let genericPassword: KeychainItemClassValue = .init(rawValue: kSecClassGenericPassword)
+    public static let genericPassword: KeychainItemClassValue = .init(rawValue: kSecClassGenericPassword)
     
     /**
      The value that indicates an Internet password item.
      
      A value wrapping the [`kSecClassInternetPassword`](https://developer.apple.com/documentation/security/ksecclassinternetpassword) value.
      */
-    static let internetPassword: KeychainItemClassValue = .init(rawValue: kSecClassInternetPassword)
+    public static let internetPassword: KeychainItemClassValue = .init(rawValue: kSecClassInternetPassword)
     
     /**
      The value that indicates a certificate item.
      
      A value wrapping the [`kSecClassCertificate`](https://developer.apple.com/documentation/security/ksecclasscertificate) value.
      */
-    static let certificate: KeychainItemClassValue = .init(rawValue: kSecClassCertificate)
+    public static let certificate: KeychainItemClassValue = .init(rawValue: kSecClassCertificate)
     
     /**
      The value that indicates a cryptographic key item.
      
      A value wrapping the [`kSecClassKey`](https://developer.apple.com/documentation/security/ksecclasskey) value.
      */
-    static let key: KeychainItemClassValue = .init(rawValue: kSecClassKey)
+    public static let key: KeychainItemClassValue = .init(rawValue: kSecClassKey)
     
     /**
      The value that indicates an identity item.
      
      A value wrapping the [`kSecClassIdentity`](https://developer.apple.com/documentation/security/ksecclassidentity) value.
      */
-    static let identity: KeychainItemClassValue = .init(rawValue: kSecClassIdentity)
+    public static let identity: KeychainItemClassValue = .init(rawValue: kSecClassIdentity)
 }
 
 public struct KeychainItemAttributeValue: KeychainItemValue {
@@ -87,8 +91,8 @@ public struct KeychainItemValueTypeValue: KeychainItemValue {
         return .init(rawValue: data)
     }
     
-    public static func data(for string: String) -> KeychainItemValueTypeValue {
-        let data = string.data(using: .utf8)
+    public static func data(for string: String, using encoding: String.Encoding = .utf8) -> KeychainItemValueTypeValue {
+        let data = string.data(using: encoding)
         return .init(rawValue: data as Any)
     }
 }

--- a/Sources/KeychainStatus.swift
+++ b/Sources/KeychainStatus.swift
@@ -1,5 +1,5 @@
 //
-//  KeychainError.swift
+//  KeychainStatus.swift
 //  Keychaining
 //
 //  Created by Jaewon Yun on 2023/03/18.
@@ -7,8 +7,9 @@
 
 import Foundation
 
-public enum KeychainError: OSStatus, Error {
+public enum KeychainStatus: OSStatus, Error {
     
+    case success                            = 0
     case unimplemented                      = -4
     case diskFull                           = -34
     case IO                                 = -36
@@ -402,7 +403,7 @@ public enum KeychainError: OSStatus, Error {
     }
 }
 
-public extension KeychainError {
+public extension KeychainStatus {
     
     var errorCode: OSStatus {
         return self.rawValue

--- a/Sources/OSStatus+toReadableString.swift
+++ b/Sources/OSStatus+toReadableString.swift
@@ -8,11 +8,15 @@
 import Foundation
 import CoreFoundation
 
-@available(iOS 11.3, *)
 extension OSStatus {
     
     /// `OSStatus` 코드를 읽을 수 있는 문자열로 만들어 반환합니다.
+    @available(iOS 11.3, *)
     public var toReadableString: String? {
         return SecCopyErrorMessageString(self, nil) as? String
+    }
+    
+    public var asKeychainStatus: KeychainStatus {
+        return .init(status: self) ?? .unspecifiedError
     }
 }


### PR DESCRIPTION
New Features
- Make a query without initialized class type.
- Specify encoding type when you set data for string. #1 
- New Class `KeychainDictionary` for using only dictionary type.
- Convertible `OSStatus` to `KeychainStatus`

Changes
- Enum name changed(`KeychainError` -> `KeychainStatus`).
- Changed method signature for make basic query
- Update deployment target version 11.0 to 12.4